### PR TITLE
Fix #22 cannot read property 'bind' of undefined

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -50,30 +50,34 @@ class VisibilityState {
 	}
 }
 
+function bind (el, { value }, vnode) {
+  if (typeof IntersectionObserver === 'undefined') {
+    console.warn('[vue-observe-visibility] IntersectionObserver API is not available in your browser. Please install this polyfill: https://github.com/w3c/IntersectionObserver/tree/master/polyfill')
+  } else {
+    const state = new VisibilityState(el, value, vnode)
+    el._vue_visibilityState = state
+  }
+};
+
+function update (el, { value }, vnode) {
+  const state = el._vue_visibilityState
+  if (state) {
+    state.createObserver(value, vnode)
+  } else {
+    bind(el, { value }, vnode)
+  }
+};
+
+function unbind (el) {
+  const state = el._vue_visibilityState
+  if (state) {
+    state.destroyObserver()
+    delete el._vue_visibilityState
+  }
+};
+
 export default {
-	bind (el, { value }, vnode) {
-		if (typeof IntersectionObserver === 'undefined') {
-			console.warn('[vue-observe-visibility] IntersectionObserver API is not available in your browser. Please install this polyfill: https://github.com/w3c/IntersectionObserver/tree/master/polyfill')
-		} else {
-			const state = new VisibilityState(el, value, vnode)
-			el._vue_visibilityState = state
-		}
-	},
-
-	update (el, { value }, vnode) {
-		const state = el._vue_visibilityState
-		if (state) {
-			state.createObserver(value, vnode)
-		} else {
-			this.bind(el, { value }, vnode)
-		}
-	},
-
-	unbind (el) {
-		const state = el._vue_visibilityState
-		if (state) {
-			state.destroyObserver()
-			delete el._vue_visibilityState
-		}
-	},
+	bind,
+	update,
+	unbind,
 }


### PR DESCRIPTION
https://github.com/Akryum/vue-observe-visibility/issues/22

Vue calls the directive functions without the dot notation or binding the source object. This means `this` will be `undefined`.

Offending lines in vue.esm.js:
```js
function callHook$1 (dir, hook, vnode, oldVnode, isDestroy) {
  var fn = dir.def && dir.def[hook];
  if (fn) {
    try {
      fn(vnode.elm, dir, vnode, oldVnode, isDestroy); // calling fn() means this will be undefined
    } catch (e) {
      handleError(e, vnode.context, ("directive " + (dir.name) + " " + hook + " hook"));
    }
  }
}
```

I solved this by just creating the functions in module scope and calling bind directly.

Note untested code, i just used Githubs editing interface, but i believe it will work (famous last words?)