### PR TITLE
add typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import Vue, { PluginFunction } from "vue"
+import { DirectiveOptions } from 'vue/types/options'
+
+export const ObserveVisibility: DirectiveOptions
+
+export default class VueObserveVisibilityPlugin {
+	static install: PluginFunction<never>
+}


### PR DESCRIPTION
This change adds a typescript definition file allowing typescript users to use this plugin out of the box.
This change can be merged and tagged as-is, since it is non-functional.
Still, this is very important for typescript users.