### PR TITLE
fix observer null issue

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -46,7 +46,8 @@ class VisibilityState {
 
 		// Wait for the element to be in document
 		vnode.context.$nextTick(() => {
-			this.observer.observe(this.el)
+			if (this.observer) this.observer.observe(this.el)
+			else this.destroyObserver()
 		})
 	}
 

--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -46,8 +46,9 @@ class VisibilityState {
 
 		// Wait for the element to be in document
 		vnode.context.$nextTick(() => {
-			if (this.observer) this.observer.observe(this.el)
-			else this.destroyObserver()
+			if (this.observer) {
+				this.observer.observe(this.el)
+			}
 		})
 	}
 


### PR DESCRIPTION
After several routing, I saw some element occur null exception on $nextTick.
So I added checking logic for observer null or not.
if ovserver is null, call estoryObserver().