### PR TITLE
check if observer is not null

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -46,7 +46,9 @@ class VisibilityState {
 
 		// Wait for the element to be in document
 		vnode.context.$nextTick(() => {
-			this.observer.observe(this.el)
+			if (this.observer) {
+			  this.observer.observe(this.el)
+			}
 		})
 	}
 


### PR DESCRIPTION
fixes cannot read property of 'observe' of null we get from time to time. The handle is somehow destroyed before nextTick is called, and then it's null which causes this error. Simple check if observer is still defined before doing "observe()" fixes it.