### PR TITLE
Fix observer callback when multiple entries are passed

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -36,7 +36,7 @@ class VisibilityState {
 		this.oldResult = undefined
 
 		this.observer = new IntersectionObserver(entries => {
-			var entry = entries[0]
+			var entry = entries.reduce((e1, e2) => e1.time > e2.time ? e1 : e2);
 			if (this.callback) {
 				// Use isIntersecting if possible because browsers can report isIntersecting as true, but intersectionRatio as 0, when something very slowly enters the viewport.
 				const result = entry.isIntersecting && entry.intersectionRatio >= this.threshold


### PR DESCRIPTION
When IntersectionObserver is triggered multiple times in a short span of time, the array passed to the callback can contain multiple elements. The user callback should be called with the last known state, i.e. the entry that has the biggest time attribute.