### PR TITLE
Simplify threshold type check

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -9,7 +9,7 @@ class VisibilityState {
 	}
 
 	get threshold () {
-		return this.options.intersection && typeof this.options.intersection.threshold === 'number' ? this.options.intersection.threshold : 0
+		return typeof this.options.intersection.threshold === 'number' ? this.options.intersection.threshold : 0
 	}
 
 	createObserver (options, vnode) {


### PR DESCRIPTION
Simplify threshold type check: the `typeof this.options.intersection.threshold === 'number'` check already covers the intent of the  `this.options.intersection` check