### PR TITLE
fix: threshold array callback

### DIFF
--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -52,16 +52,11 @@ class VisibilityState {
 			}
 
 			if (this.callback) {
-				if (Array.isArray(this.threshold)) {
-					const result = entry.isIntersecting
-					this.oldResult = result
-					this.callback(result, entry)
-					return
+				if (!Array.isArray(this.threshold)) {
+					// Use isIntersecting if possible because browsers can report isIntersecting as true, but intersectionRatio as 0, when something very slowly enters the viewport.
+					const result = entry.isIntersecting && entry.intersectionRatio >= this.threshold
+					if (result === this.oldResult) return
 				}
-
-				// Use isIntersecting if possible because browsers can report isIntersecting as true, but intersectionRatio as 0, when something very slowly enters the viewport.
-				const result = entry.isIntersecting && entry.intersectionRatio >= this.threshold
-				if (result === this.oldResult) return
 				this.oldResult = result
 				this.callback(result, entry)
 			}

--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -52,9 +52,10 @@ class VisibilityState {
 			}
 
 			if (this.callback) {
+				let result = entry.isIntersecting
 				if (!Array.isArray(this.threshold)) {
 					// Use isIntersecting if possible because browsers can report isIntersecting as true, but intersectionRatio as 0, when something very slowly enters the viewport.
-					const result = entry.isIntersecting && entry.intersectionRatio >= this.threshold
+					result &&= entry.intersectionRatio >= this.threshold
 					if (result === this.oldResult) return
 				}
 				this.oldResult = result

--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -10,7 +10,7 @@ class VisibilityState {
 	}
 
 	get threshold () {
-		return this.options.intersection && typeof this.options.intersection.threshold === 'number' ? this.options.intersection.threshold : 0
+		return this.options.intersection?.threshold || 0
 	}
 
 	createObserver (options, vnode) {

--- a/src/directives/observe-visibility.js
+++ b/src/directives/observe-visibility.js
@@ -52,6 +52,13 @@ class VisibilityState {
 			}
 
 			if (this.callback) {
+				if (Array.isArray(this.threshold)) {
+					const result = entry.isIntersecting
+					this.oldResult = result
+					this.callback(result, entry)
+					return
+				}
+
 				// Use isIntersecting if possible because browsers can report isIntersecting as true, but intersectionRatio as 0, when something very slowly enters the viewport.
 				const result = entry.isIntersecting && entry.intersectionRatio >= this.threshold
 				if (result === this.oldResult) return


### PR DESCRIPTION
If the Threshold is an Array we cannot check for ´entry.intersectionRatio >= this.threshold´ because it will always be false, so the callback is not executed correctly. We need to call it if it finds an intersection with the array that we provided.